### PR TITLE
Modified the gen_htaccess script to use text/plain rather than text/html

### DIFF
--- a/couch/functions.php
+++ b/couch/functions.php
@@ -1302,11 +1302,10 @@
                 array_multisort( $depth, SORT_DESC, SORT_NUMERIC, $pretty_tpl_names, SORT_DESC, SORT_STRING, $rs );
 
                 // Loop once again through the templates, generating rewrite rules for each.
-                $header = '<!doctype html>';
-                $header .= '<html style="background-color:#fff;"><body style="line-height:16px;padding:15px;margin:0;font-family:Menlo,Monaco,Consolas,\'Courier New\',monospace;font-size:12px;">';
+                $header = '';
                 $for_index = '';
                 $body = '';
-                $sep = '<br>';
+                $sep = "\n";
                 foreach( $rs as $key=>$val ){
                     $body .= $sep . '#'. $val['name'] . $sep;
                     if( $val['is_index'] ){
@@ -1361,7 +1360,7 @@
 
                 // Send back the consolidated rules
                 $header .= 'Options +FollowSymlinks -MultiViews' . $sep;
-                $header .= '&lt;IfModule mod_rewrite.c&gt;' . $sep;
+                $header .= '<IfModule mod_rewrite.c>' . $sep;
                 $header .= 'RewriteEngine On' . $sep;
                 $header .= $sep;
                 $header .= '#If your website is installed in a subfolder, change the line below to reflect the path to the subfolder.' . $sep;
@@ -1386,8 +1385,7 @@
                 $header .= 'RewriteCond %{REQUEST_FILENAME} -f' . $sep;
                 $header .= 'RewriteRule . - [L]' . $sep;
 
-                $footer = '&lt;/IfModule&gt;';
-                $footer .= '</body></html>';
+                $footer = '</IfModule>';
 
                 return $header . $body . $footer;
             }

--- a/couch/gen_htaccess.php
+++ b/couch/gen_htaccess.php
@@ -36,14 +36,12 @@
     */
 
     ob_start();
-
     if ( !defined('K_COUCH_DIR') ) define( 'K_COUCH_DIR', str_replace( '\\', '/', dirname(realpath(__FILE__) ).'/') );
     require_once( K_COUCH_DIR.'header.php' );
-    header( 'Content-Type: text/html; charset='.K_CHARSET );
+    header( 'Content-Type: text/plain; charset='.K_CHARSET );
 
     define( 'K_ADMIN', 1 );
 
-    $AUTH->check_access( K_ACCESS_LEVEL_ADMIN, 1 );
-
+    if(php_sapi_name() != 'cli') $AUTH->check_access( K_ACCESS_LEVEL_ADMIN, 1 );
 
     echo $FUNCS->generate_rewrite_rules();


### PR DESCRIPTION
Can then use `php couch/gen_htaccess.php > .htaccess` on the server to update the htaccess file without having to load it in a separate web browser and copy/paste into a text editor.

There is then a check to see if the script is being run on the server itself, and if so, it disables the check to see if the user is logged into the web admin panel.