### PR TITLE
unicode name generation

### DIFF
--- a/couch/page.php
+++ b/couch/page.php
@@ -871,7 +871,11 @@
             }
 
             if( $name=='' && $title!='' ){
-                $name = $FUNCS->get_clean_url( $title );
+                $name = $FUNCS->get_clean_url( $title );				
+                if ($name=='' && function_exists('transliterator_transliterate')) {
+					$transliterated_title = transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $title);
+					$name = $FUNCS->get_clean_url($transliterated_title);
+				}
                 // verify the name does not already exist
                 $unique = false;
                 $unique_id = 1;


### PR DESCRIPTION
These 4 lines will generate pretty page name from a title of virtually any character set.
The original version does remove accents, but completely ingores cyrillics.
transliterator_transliterate is a PHP function from the module intl.
If intl is not installed, the code will work as before.