### PR TITLE
Fixed serious bug with cookie handling

### DIFF
--- a/couch/auth/auth.php
+++ b/couch/auth/auth.php
@@ -216,12 +216,7 @@
             $cookie_expiry = time() + (3600 * 24 * $days_valid);
             $cookie = $this->create_cookie( $username, $cookie_expiry );
             if( version_compare(phpversion(), '5.2.0', '>=') ) {
-                if( $remember ){
-                    setcookie( $this->cookie_name, $cookie, $cookie_expiry, $this->cookie_path, null, K_HTTPS ? true : null, true );
-                }
-                else{
-                    setcookie( $this->cookie_name, $cookie, 0, $this->cookie_path, null, K_HTTPS ? true : null, true );
-                }
+                setcookie( $this->cookie_name, $cookie, $cookie_expiry, $this->cookie_path, null, K_HTTPS ? true : null, true );
             }
             else{
                 if( $remember ){


### PR DESCRIPTION
First, I don't see Remember me button anywhere in the login screen.
Second, the "if... else" I removed made no sense.
I suppose the $remember variable was meant to keep user logged in for 2 weeks if true and 24 hours if false.
So essentially the $days_vaild value was just ignored if $remember=0, thus invoking a VERY SERIOUS BUG, which I have described here:
http://www.couchcms.com/forum/viewtopic.php?f=4&t=9391