### PR TITLE
output 'required' parameter for input fields

### DIFF
--- a/couch/field.php
+++ b/couch/field.php
@@ -1039,6 +1039,9 @@
             global $FUNCS, $CTX;
 
             $value = $this->get_data();
+            if( $this->required ){ //Output required parameter in html
+                $extra .= ' required="required"';
+            }
             if( $this->k_type=='text' || $this->k_type=='password' || $this->k_type=='submit' || $this->k_type=='hidden' ){
                 $html = '<input type="'.$this->k_type.'" name="'.$input_name.'"  id="'.$input_id.'" value="'.htmlspecialchars( $value, ENT_QUOTES, K_CHARSET ).'" '.$extra.'/>';
             }


### PR DESCRIPTION
While you are tweaking v2.0 beta into it's final shape, I thought it would be a good opportunity to slip this simple update into the rendering of form fields.

Adding this parameter to the html output allows for browser-based validation of required fields. To me it seems like the appropriate and expected behavior.

Backwards compatibility could be a concern if people's forms suddenly begin behaving differently. But it is a small change, it can be reversed by the novalidate parameter, and as I mentioned, in 2016 it seems like the expected behavior.

I chose to write the parameter as required="required", but there are other ways to express it as well.