### PR TITLE
Update cms:add_querystring to avoid orphan "?"

### DIFF
--- a/couch/tags.php
+++ b/couch/tags.php
@@ -870,8 +870,9 @@
             // sanitize params
             $link = trim( $link );
             $querystring = trim( $querystring );
-
-            $sep = ( strpos($link, '?')===false ) ? '?' : '&';
+            if( $querystring ){
+                $sep = ( strpos($link, '?')===false ) ? '?' : '&';
+            }    
             return $link . $sep . $querystring;
         }
 


### PR DESCRIPTION
If querystring gets added via user-variable, then user-variable can be empty. This leaves link with a symbol '?' which needs not to be there without tail.