### PR TITLE
A new hook for smart_embed

### DIFF
--- a/couch/tags.php
+++ b/couch/tags.php
@@ -721,6 +721,9 @@
                     $valid_files[] = 'default';
                 }
 
+                // HOOK: alter_valid_files
+                $FUNCS->dispatch_event( 'alter_valid_files', array(&$valid_files, $tplname) );
+
                 // Cache results
                 $FUNCS->cached_valid_files_for_view = $valid_files;
             }


### PR DESCRIPTION
Allows to amend the list of default look-up files on the fly for 'cms:smart_embed' tag.