### PR TITLE
Customisable "Default" admin groups

### DIFF
--- a/couch/base.php
+++ b/couch/base.php
@@ -384,8 +384,9 @@
                 'content'=>"<cms:render 'group_custom_fields' />",
                 'order'=>20,
             );
-			// 4. Allow more field groups - Primarily for admin panel theme developers
-			 $FUNCS->dispatch_event( 'add_default_field_group', array(&$arr_fields));
+
+            // 4. Allow more field groups - Primarily for admin panel theme developers
+            $FUNCS->dispatch_event( 'add_default_field_group', array(&$arr_fields));
         }
 
         function _set_default_fields( &$arr_fields ){

--- a/couch/base.php
+++ b/couch/base.php
@@ -376,6 +376,8 @@
                 'content'=>"<cms:render 'group_custom_fields' />",
                 'order'=>20,
             );
+			// 4. Allow more field groups - Primarily for admin panel theme developers
+			 $FUNCS->dispatch_event( 'add_default_field_group', array(&$arr_fields));
         }
 
         function _set_default_fields( &$arr_fields ){

--- a/couch/base.php
+++ b/couch/base.php
@@ -359,6 +359,7 @@
         }
 
         function _set_default_field_groups( &$arr_fields ){
+			global $FUNCS;
             // divide fields into three groups - 'advanced settings', 'sytem_fields' and 'custom_fields'
             // 1. advanced settings
             $arr_fields[ '_advanced_settings_' ] = array( 'no_wrapper'=>'1' );


### PR DESCRIPTION
This allows admin panel theme developers to expand upon the default field groups "system fields" and "advanced fields" and add more of their own when customizing the admin panel theme or creating your own.