### PR TITLE
Skip regex for double bars

### DIFF
--- a/couch/tags.php
+++ b/couch/tags.php
@@ -405,6 +405,9 @@
                 elseif( $sep == '\t' ){
                     $sep = "\t";
                 }
+                elseif( $sep == '||' ){
+                    $sep = "||";
+                }                
                 else{
                     $use_preg=1;
                 }


### PR DESCRIPTION
Could we avoid regex processing of double bars separator? Handy for checkboxes and radio.