### PR TITLE
Avoid duplication

### DIFF
--- a/couch/theme/_system/register.php
+++ b/couch/theme/_system/register.php
@@ -1345,7 +1345,7 @@
                         },
                     })
                     .done(function( data ){
-                        $( '#listing' ).replaceWith( $( $.parseHTML( data, document ) ).find( '#listing' ) );
+                        $( '#listing' ).replaceWith( $( $.parseHTML( data, document ) ).find( '#listing' ).first() );
                     })
                     .always(function() {
                         $('#k_overlay').css('display', 'none');


### PR DESCRIPTION
Oh, something happened to me today after adding k_up_down ordering to a gallery. 
Immediately after trying to order a page go right, I had 2 sets of pictures on page.
If list-view had an output of cms:dump_all somewhere, then such dump would contain content of backend snippets as expected. 
Getting such page via ajax returns every instance of <div id="listing">, so jQuery code must make sure to get the first one.