### PR TITLE
Improve field loading speed

### DIFF
--- a/couch/page.php
+++ b/couch/page.php
@@ -847,7 +847,7 @@
 
             if( count($rs) ){
                 foreach( $rs as $rec ){
-                    for( $x=0; $x<count($this->fields); $x++ ){
+                    for( $x=0, $count = count($this->fields); $x<$count; $x++ ){
                         $dest = &$this->fields[$x];
                         if( $dest->id == $rec['field_id'] && !$dest->system ){
                             $dest->store_data_from_saved( $rec['value'] );


### PR DESCRIPTION
Counting fields each step for every db row, uhh..
Suggestion roughly shaves off 20% of loop time. Tested successfully for ~500 fields: 1.1 sec -> 0.9 sec.