### PR TITLE
Update functions.php

### DIFF
--- a/couch/functions.php
+++ b/couch/functions.php
@@ -3409,6 +3409,74 @@ OUT;
 
             return $this->_t[$key];
         }
+        
+		// Utility func to get the translated month names by number
+		// Uses the names given in the language files
+		// $monthNum 	=> (int) 	Month number(1 - 12)
+		// $short		=> (bool)	Generate shortcode name
+		// $case		=> (int) 	0 = as-is
+		//							> 0 = fully uppercase
+		//							< 0 = fully lowercase
+		function monthname ($monthNum, $short=false, $case=0) {
+			settype ( $monthNum , "int");
+			settype ($case, "int");
+            $arrMonths = array(1=>$FUNCS->t('month01'), 2=>$FUNCS->t('month02'), 3=>$FUNCS->t('month03'), 4=>$FUNCS->t('month04'),
+                               5=>$FUNCS->t('month05'), 6=>$FUNCS->t('month06'), 7=>$FUNCS->t('month07'), 8=>$FUNCS->t('month08'),
+                               9=>$FUNCS->t('month09'), 10=>$FUNCS->t('month10'), 11=>$FUNCS->t('month11'), 12=>$FUNCS->t('month12'));			
+            $arrS_Months = array(1=>$FUNCS->t('s_month01'), 2=>$FUNCS->t('s_month02'), 3=>$FUNCS->t('s_month03'), 4=>$FUNCS->t('s_month04'),
+                               5=>$FUNCS->t('s_month05'), 6=>$FUNCS->t('s_month06'), 7=>$FUNCS->t('s_month07'), 8=>$FUNCS->t('s_month08'),
+                               9=>$FUNCS->t('s_month09'), 10=>$FUNCS->t('s_month10'), 11=>$FUNCS->t('s_month11'), 12=>$FUNCS->t('s_month12'));			
+			if ($short=false) { 
+				if ($case == 0) {
+					return $arrMonths[$monthNum];
+				} else if ($case < 0) {
+					return lowercase($arrMonths[$monthNum]);
+				} else {
+					return uppercase($arrMonths[$monthNum]);
+				}
+			} else {
+				if ($case == 0) {
+					return $arrS_Months[$monthNum];
+				} else if ($case < 0) {
+					return lowercase($arrS_Months[$monthNum]);
+				} else {
+					return uppercase($arrS_Months[$monthNum]);
+				}
+			}
+		}
+
+		// Utility func to get the translated day names by number
+		// Uses the names given in the language files
+		// $dayNum 		=> (int) 	day number (0 - 7, corrected for the use of the w or N parameter on date function)
+		// $short		=> (bool)	Generate shortcode name
+		// $case		=> (int) 	0 = as-is
+		//							> 0 = fully uppercase
+		//							< 0 = fully lowercase
+		function dayname ($dayNum, $short=false, $case=0) {
+			settype ( $dayNum , "int" );
+			settype ( $case, "int");
+            $arrDays = array(	0=>$FUNCS->t('day0'), 1=>$FUNCS->t('day1'), 2=>$FUNCS->t('day2'), 3=>$FUNCS->t('day3'), 
+								4=>$FUNCS->t('day4'), 5=>$FUNCS->t('day5'), 6=>$FUNCS->t('day6'), 7=>$FUNCS->t('day7'));	
+            $arrS_Days = array(	0=>$FUNCS->t('s_day0'), 1=>$FUNCS->t('s_day1'), 2=>$FUNCS->t('s_day2'), 3=>$FUNCS->t('s_day3'), 
+								4=>$FUNCS->t('s_day4'), 5=>$FUNCS->t('s_day5'), 6=>$FUNCS->t('s_day6'), 7=>$FUNCS->t('s_day7'));	
+			if ($short=false) { 
+				if ($case == 0) {
+					return $arrDays[$dayNum];
+				} else if ($case < 0) {
+					return lowercase($arrDays[$dayNum]);
+				} else {
+					return uppercase($arrDays[$dayNum]);
+				}
+			} else {
+				if ($case == 0) {
+					return $arrS_Days[$dayNum];
+				} else if ($case < 0) {
+					return lowercase($arrS_Days[$dayNum]);
+				} else {
+					return uppercase($arrS_Days[$dayNum]);
+				}
+			}
+		}
 
         function ti( $icon_name ){
 


### PR DESCRIPTION
Added 2 new functions to enable translation of month and day names.
- monthname ($monthNum, $short=false, $case=0)
- dayname ($dayNum, $short=false, $case=0)
It uses translated names in the translation files (see EN.php and NL.php for examples)
It supports the use of shorthand names on both the month and day names.
The functions use the month and day number as a selector for the name and a bool to select shorthand or not. Also supports an option to select the return of a uppercase, lowercase or as-is translated name.
Hope this will make it more easy and coherent across the translations how to name months and days in the front and back-end.