### PR TITLE
Added the use of monthname

### DIFF
--- a/couch/addons/mosaic/theme/fields/ctx-setters.php
+++ b/couch/addons/mosaic/theme/fields/ctx-setters.php
@@ -17,8 +17,12 @@
                         $arrMonths = explode( ',', $f->months );
                     }
                     else{
-                        $arrMonths = array( 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec');
-                    }
+//                      $arrMonths = array( 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec');
+// Use translated short monthnames instead
+						for( $xx=1; $xx<=12; $xx++ ){
+							$arrMonths[$xx-1]= $FUNCS->monthname($xx,true,0);
+						}
+                     }
                     $month = $arrMonths[intval($month)-1];
 
                     switch( $f->format ){


### PR DESCRIPTION
To support the monthname function (function.php) for the default month names so the language files are used to populate the real month names for a selected language just like the editation of the datetime field.