### PR TITLE
[PHP 8.1] Fix `mysqli_get_client_info` deprecation

### DIFF
--- a/couch/includes/mysql2i/mysql2i.class.php
+++ b/couch/includes/mysql2i/mysql2i.class.php
@@ -274,9 +274,7 @@
 
       public static function mysql_get_client_info(){
 
-          $link = self::$currObj;
-
-          return mysqli_get_client_info($link);
+          return mysqli_get_client_info();
       }
 
       public static function mysql_get_host_info($link=null){


### PR DESCRIPTION
In PHP 8.1, [calling `mysqli_get_client_info` function with parameters is deprecated](https://php.watch/versions/8.1/mysqli_get_client_info-deprecation).
Fixing the existing `\mysql2i::mysql_get_client_info` call to not pass any parameters.