### PR TITLE
Update sidebar.html

### DIFF
--- a/couch/theme/_system/sidebar.html
+++ b/couch/theme/_system/sidebar.html
@@ -25,7 +25,7 @@
                 <ul>
                 <cms:admin_menuitems depth='1' childof=k_menu_name>
                     <li>
-                        <a class="<cms:if k_menu_icon >nav-icon</cms:if><cms:if k_is_current> nav-active</cms:if> <cms:show k_menu_class />" title="<cms:show k_menu_name />" href="<cms:show k_menu_link />">
+                        <a class="<cms:if k_menu_icon >nav-icon </cms:if><cms:if k_is_current>nav-active</cms:if> <cms:show k_menu_class />" title="<cms:show k_menu_name />" href="<cms:show k_menu_link />">
                             <cms:if k_menu_icon >
                                 <cms:show_icon k_menu_icon />
                             </cms:if>


### PR DESCRIPTION
Avoid starting space for template without icons.

It is a bit harder to write selectors such as `$("a[class^='nav']")` if non-clonable templates have a leading space, and clonables do not.