### PR TITLE
Fix a glitch with deleting fields

### DIFF
--- a/couch/theme/_system/form_field_deleted.html
+++ b/couch/theme/_system/form_field_deleted.html
@@ -27,7 +27,7 @@
                     dataType: "text",
                     url:      qs
                 }).done(function( data ) {
-                    if( data === "OK" ){
+                    if( data.trim() === "OK" ){
                         var $field = $('#k_element_'+fname);
 
                         COUCH.slideFadeHide( $field, 400, function() {


### PR DESCRIPTION
Empty spaces before the opening PHP tag anywhere in the user code (such as a shortcode func) will break the handling of ajax response in `k_delete_field` function. Actual happening https://github.com/trendoman/Tweakus-Dilectus/commit/fc9f34d3346b26f205777f9d337247a252d1d4a7
