### PR TITLE
Update sub-templates.php

### DIFF
--- a/couch/addons/sub-templates/sub-templates.php
+++ b/couch/addons/sub-templates/sub-templates.php
@@ -980,7 +980,7 @@
             }
         }
 
-        function alter_page_context( &$vars, &$pg ){
+        static function alter_page_context( &$vars, &$pg ){
             global $FUNCS, $DB;
             static $cache = array();
 


### PR DESCRIPTION
Makes alter_page_context() a static function (like the rest of its siblings) to avoid fatal PHP 8.3 error downstream in couch/event.php line 97.