### PR TITLE
Enables JSON Pretty Print via <cms:show />

### DIFF
--- a/couch/functions.php
+++ b/couch/functions.php
@@ -4602,15 +4602,15 @@ OUT;
             return $tmp_dir;
         }
 
-        function json_encode( $value ){
-            if( function_exists('json_encode') ) return json_encode( $value );
+        function json_encode( $value, $options = 0 ){
+            if( function_exists('json_encode') ) return json_encode( $value, $options );
 
             if( !class_exists('Services_JSON') ){
                 require_once( K_COUCH_DIR . 'includes/JSON.php' );
             }
             if( is_null($this->json) ) $this->json = new Services_JSON( SERVICES_JSON_LOOSE_TYPE );
 
-            return $this->json->encode( $value );
+            return $this->json->encode( $value, $options );
         }
 
         function json_decode( $value ){

--- a/couch/tags.php
+++ b/couch/tags.php
@@ -118,6 +118,7 @@
                         array( 'var'=>'', /*placeholder*/
                                'scope'=>'',
                                'as_json'=>'0',
+                               'json_pretty'=> '0',
                               ),
                         $params)
                    );
@@ -125,6 +126,7 @@
             $value = $params[0]['rhs'];
             $scope = strtolower( trim($scope) );
             $as_json = ( $as_json==1 ) ? 1 : 0;
+            $json_pretty = ( $json_pretty==1 ) ? 1 : 0;
 
             // If scope set and first param is a variable, return variable only from the specified scope scope.
             if( $scope != '' && $node->attributes[0]['value_type']==K_VAL_TYPE_VARIABLE ){
@@ -136,7 +138,7 @@
                 $value = $CTX->get( $node->attributes[0]['value'], $scope );
             }
 
-            if( $as_json && is_array($value) ){ $value = $FUNCS->json_encode( $value ); }
+            if( $as_json && is_array($value) ){ $value = $FUNCS->json_encode($value, $json_pretty ? JSON_PRETTY_PRINT : 0); }
             return $value;
         }
 


### PR DESCRIPTION
This ensembles a new option in `<cms:show />` to pretty print JSON output. Requires `<cms:content_type 'application/json' />` or `<cms:content_type 'text/plain' />` to see it in action. Useful for certain renderings in `<pre>` tags especially 🙂

**Note**: I'd be open to ` pretty='1' ` instead of ` json_pretty='1' `, but I figured ` json_pretty ` may be more future-proof if other pretty printing options were introduced later on (YAML, etc).

Hope this is useful for other Couch developers!