### PR TITLE
[PHP 8.4] Fix: Curl `CURLOPT_BINARYTRANSFER` deprecated

### DIFF
--- a/couch/addons/mosaic/gc/gc.php
+++ b/couch/addons/mosaic/gc/gc.php
@@ -176,7 +176,6 @@
                     curl_setopt( $ch, CURLOPT_URL, $url );
                     curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
                     curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
-                    curl_setopt( $ch, CURLOPT_BINARYTRANSFER, 1 );
                     curl_setopt( $ch, CURLOPT_FORBID_REUSE, 1 );
                     curl_setopt( $ch, CURLOPT_FRESH_CONNECT, 1 );
                     curl_setopt( $ch, CURLOPT_TIMEOUT, $timeout );

--- a/couch/functions.php
+++ b/couch/functions.php
@@ -4322,7 +4322,6 @@ OUT;
                 }
                 curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
                 //curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, 1 ); //problematic
-                curl_setopt( $ch, CURLOPT_BINARYTRANSFER, 1 );
                 curl_setopt( $ch, CURLOPT_FORBID_REUSE, 1 );
                 curl_setopt( $ch, CURLOPT_FRESH_CONNECT, 1 );
                 curl_setopt( $ch, CURLOPT_TIMEOUT, 0 );


### PR DESCRIPTION
The `CURLOPT_BINARYTRANSFER` PHP constant from the Curl extension was no-op since PHP 5.1, and is deprecated in PHP 8.4. This removes the constant usage to avoid the deprecation notice in PHP 8.4 and later.

Because this constant was no-op since PHP 5.1 (circa 2005), this change has no impact.

See:

 - [PHP.Watch - PHP 8.4 - Curl: CURLOPT_BINARYTRANSFER deprecated](https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated)
 - [commit](https://github.com/php/php-src/commit/fc16285538e96ecb35d017231051f83dcbd8b55b)